### PR TITLE
feat: frontend HistorySidebar.tsx 신규 구현 및 `App.tsx`에 마운트 완료 / 스트리밍 결과…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,12 +5,13 @@ import { TimeoutToast } from './components/Loading/TimeoutToast';
 import { IdeaInput } from './components/Form/IdeaInput';
 import { ResultView } from './components/Result/ResultView';
 import { ErrorFallback } from './components/common/ErrorFallback';
+import { HistorySidebar } from './components/History/HistorySidebar';
 import { useRagStream } from './hooks/useRagStream';
 
 function App() {
     const [idea, setIdea] = useState('');
 
-    // RAG 상태 관리 훅
+    // RAG 분석 상태 관리 훅
     const {
         isAnalyzing,
         isSkeletonVisible,
@@ -25,9 +26,15 @@ function App() {
         setErrorInfo
     } = useRagStream();
 
+    // 폼 제출: 아이디어 텍스트를 상태에 저장하고 RAG 분석 시작
     const handleSubmitIdea = (inputIdea: string) => {
         setIdea(inputIdea);
         startAnalysis(inputIdea);
+    };
+
+    // 히스토리 항목 클릭: 해당 아이디어를 입력창에 채우기 위해 상위 상태 업데이트
+    const handleSelectHistory = (selectedIdea: string) => {
+        setIdea(selectedIdea);
     };
 
     const handleReset = () => {
@@ -36,61 +43,86 @@ function App() {
     };
 
     return (
-        <main className="min-h-screen p-8 flex flex-col items-center bg-gray-50">
-            <h1 className="text-4xl font-extrabold text-blue-900 mb-2">💡 쇼특허 (Short-Cut) AI</h1>
-            <p className="text-gray-500 mb-10 font-medium">아이디어만 입력하면 AI가 실시간으로 특허 침해 여부를 분석해 드립니다.</p>
+        <div className="min-h-screen bg-gray-50">
+            {/* 페이지 헤더 */}
+            <header className="bg-white border-b border-gray-100 px-8 py-5 shadow-sm">
+                <h1 className="text-2xl font-extrabold text-blue-900">💡 쇼특허 (Short-Cut) AI</h1>
+                <p className="text-gray-500 text-sm font-medium mt-0.5">아이디어만 입력하면 AI가 실시간으로 특허 침해 여부를 분석해 드립니다.</p>
+            </header>
 
             {/* 통신 지연 안내 토스트 (30초 초과 시 표출) */}
             <TimeoutToast isAnalyzing={isAnalyzing} timeoutMs={30000} />
 
-            {/* 에러 발생 시 Fallback UI 표시 */}
-            {errorInfo ? (
-                <ErrorFallback
-                    title={errorInfo.title}
-                    message={errorInfo.message}
-                    onRetry={() => {
-                        handleReset();
-                        setErrorInfo(null);
-                    }}
-                />
-            ) : isComplete && resultData ? (
-                <ResultView
-                    idea={idea}
-                    resultData={resultData}
-                    onReset={handleReset}
-                />
-            ) : (
-                /* 2. 메인 입력 및 로딩 화면 래퍼 */
-                <div className="w-full max-w-3xl">
-                    <IdeaInput
-                        onSubmit={handleSubmitIdea}
-                        disabled={isAnalyzing}
-                    />
+            {/* 메인 2단 레이아웃: 좌측 히스토리 사이드바 + 우측 메인 콘텐츠 */}
+            <main className="flex flex-col md:flex-row gap-6 p-6 max-w-7xl mx-auto">
 
-                    {isAnalyzing && (
-                        <div className="mt-8">
-                            <ProgressStepper
-                                percent={percent}
-                                message={message}
-                                onCancel={cancelAnalysis}
+                {/* 좌측: 분석 기록 사이드바 */}
+                <HistorySidebar
+                    onSelectIdea={handleSelectHistory}
+                    isAnalyzing={isAnalyzing}
+                />
+
+                {/* 우측: 메인 콘텐츠 영역 */}
+                <section className="flex-1 flex flex-col gap-6">
+
+                    {/* 에러 Fallback UI */}
+                    {errorInfo ? (
+                        <ErrorFallback
+                            title={errorInfo.title}
+                            message={errorInfo.message}
+                            onRetry={() => {
+                                handleReset();
+                                setErrorInfo(null);
+                            }}
+                        />
+                    ) : isComplete && resultData ? (
+                        /* 분석 완료: 결과 리포트 렌더링 */
+                        <ResultView
+                            idea={idea}
+                            resultData={resultData}
+                            onReset={handleReset}
+                        />
+                    ) : (
+                        /* 입력 및 로딩 화면 */
+                        <div className="w-full">
+                            <IdeaInput
+                                onSubmit={handleSubmitIdea}
+                                disabled={isAnalyzing}
                             />
 
-                            {isSkeletonVisible ? (
-                                <RagSkeleton lines={5} />
-                            ) : (
-                                <div className="w-full max-w-2xl mx-auto p-6 bg-white rounded-xl shadow-md border border-gray-100 mt-6 min-h-[160px]">
-                                    <div className="flex items-center gap-3 mb-4">
-                                        <div className="w-2 h-2 rounded-full bg-blue-500 animate-pulse"></div>
-                                        <h3 className="text-sm font-bold text-gray-500 uppercase tracking-wider">AI Streaming</h3>
-                                    </div>
-                                    <p className="text-gray-700 leading-relaxed font-mono">가상 LLM 스트리밍 텍스트 렌더링 시작됨... ▌</p>
+                            {/* 분석 진행 중: 프로그레스 + 스켈레톤/스트리밍 UI */}
+                            {isAnalyzing && (
+                                <div className="mt-8">
+                                    <ProgressStepper
+                                        percent={percent}
+                                        message={message}
+                                        onCancel={cancelAnalysis}
+                                    />
+
+                                    {isSkeletonVisible ? (
+                                        /* 초기 대기: 스켈레톤 shimmer 표시 */
+                                        <RagSkeleton lines={5} />
+                                    ) : (
+                                        /* 스트림 수신 중: 실제 진행 메시지를 실시간으로 표시 */
+                                        <div className="w-full mx-auto p-6 bg-white rounded-xl shadow-md border border-gray-100 mt-6 min-h-[160px]">
+                                            <div className="flex items-center gap-3 mb-4">
+                                                <div className="w-2 h-2 rounded-full bg-blue-500 animate-pulse"></div>
+                                                <h3 className="text-sm font-bold text-gray-500 uppercase tracking-wider">AI 분석 진행 중</h3>
+                                            </div>
+                                            {/* message: useRagStream에서 SSE progress 이벤트로 수신한 실시간 상태 메시지 */}
+                                            <p className="text-gray-700 leading-relaxed font-mono min-h-[2rem]">
+                                                {message || '특허 데이터베이스를 검색하고 있습니다...'}
+                                                <span className="animate-pulse ml-1">▌</span>
+                                            </p>
+                                        </div>
+                                    )}
                                 </div>
                             )}
                         </div>
                     )}
-                </div>
-            )}
-        </main>
+                </section>
+            </main>
+        </div>
     );
 }
 

--- a/frontend/src/components/History/HistorySidebar.tsx
+++ b/frontend/src/components/History/HistorySidebar.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useState, useCallback } from 'react';
+
+// 히스토리 단일 항목 타입 (백엔드 반환값 기준: user_idea, timestamp)
+interface HistoryItem {
+    id?: string;
+    user_idea: string;      // 백엔드 반환 필드명 (기존 idea_text → user_idea 확정)
+    timestamp?: string;
+    risk_level?: string;
+}
+
+interface HistorySidebarProps {
+    /** 히스토리 항목 클릭 시 아이디어 텍스트를 상위 컴포넌트로 전달하는 콜백 */
+    onSelectIdea: (idea: string) => void;
+    /** 분석이 진행 중일 때 클릭을 비활성화하기 위한 플래그 */
+    isAnalyzing: boolean;
+}
+
+export function HistorySidebar({ onSelectIdea, isAnalyzing }: HistorySidebarProps) {
+    const [histories, setHistories] = useState<HistoryItem[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [fetchError, setFetchError] = useState<string | null>(null);
+
+    // TODO: 추후 JWT 인증 헤더 방식으로 교체 필요 (현재 테스트용 고정값)
+    const USER_ID = window.ENV?.USER_ID || 'test_user_webapp';
+    const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+
+    // 히스토리 데이터 조회 (Query Parameter 방식: /history?user_id=...)
+    const fetchHistory = useCallback(async () => {
+        setIsLoading(true);
+        setFetchError(null);
+        try {
+            const res = await fetch(`${API_BASE_URL}/api/v1/history?user_id=${USER_ID}`);
+            if (!res.ok) throw new Error(`서버 응답 오류: ${res.status}`);
+            const data = await res.json();
+            setHistories(data.history || []);
+        } catch (err) {
+            console.error('[HistorySidebar] 히스토리 조회 실패:', err);
+            // 히스토리 조회 실패는 치명적이지 않으므로 빈 상태 유지 (UI 에러 표시만)
+            setFetchError('히스토리를 불러오지 못했습니다.');
+        } finally {
+            setIsLoading(false);
+        }
+    }, [API_BASE_URL, USER_ID]);
+
+    useEffect(() => {
+        fetchHistory();
+    }, [fetchHistory]);
+
+    // 위험도 뱃지 색상 결정
+    const getRiskBadgeStyle = (riskLevel?: string) => {
+        switch (riskLevel) {
+            case 'High': return 'bg-red-100 text-red-700';
+            case 'Medium': return 'bg-yellow-100 text-yellow-700';
+            case 'Low': return 'bg-green-100 text-green-700';
+            default: return 'bg-gray-100 text-gray-500';
+        }
+    };
+
+    return (
+        <aside className="w-full md:w-72 shrink-0 flex flex-col gap-3">
+            {/* 사이드바 헤더 */}
+            <div className="flex items-center justify-between px-1">
+                <h2 className="text-sm font-bold text-gray-500 uppercase tracking-widest">
+                    📋 분석 기록
+                </h2>
+                <button
+                    onClick={fetchHistory}
+                    className="text-xs text-blue-500 hover:text-blue-700 font-semibold transition-colors"
+                    disabled={isLoading}
+                    title="새로고침"
+                >
+                    {isLoading ? '로딩 중...' : '새로고침'}
+                </button>
+            </div>
+
+            {/* 로딩 스켈레톤 */}
+            {isLoading && (
+                <div className="flex flex-col gap-2">
+                    {[1, 2, 3].map((i) => (
+                        <div
+                            key={i}
+                            className="h-16 w-full bg-gray-100 rounded-lg animate-pulse"
+                        />
+                    ))}
+                </div>
+            )}
+
+            {/* 에러 상태 */}
+            {!isLoading && fetchError && (
+                <div className="p-4 bg-red-50 border border-red-200 rounded-lg text-xs text-red-600 font-medium">
+                    ⚠️ {fetchError}
+                </div>
+            )}
+
+            {/* 빈 상태 */}
+            {!isLoading && !fetchError && histories.length === 0 && (
+                <div className="p-6 text-center bg-gray-50 border-2 border-dashed border-gray-200 rounded-xl">
+                    <span className="text-3xl block mb-2">🔍</span>
+                    <p className="text-xs text-gray-500 font-medium">
+                        아직 분석 기록이 없습니다.
+                        <br />첫 번째 특허 아이디어를 검사해보세요!
+                    </p>
+                </div>
+            )}
+
+            {/* 히스토리 목록 */}
+            {!isLoading && !fetchError && histories.length > 0 && (
+                <ul className="flex flex-col gap-2">
+                    {histories.map((item, idx) => {
+                        // 텍스트 미리보기 (40자 초과 시 말줄임)
+                        const preview = item.user_idea
+                            ? item.user_idea.length > 40
+                                ? item.user_idea.substring(0, 40) + '...'
+                                : item.user_idea
+                            : '알 수 없는 아이디어';
+
+                        const dateStr = item.timestamp
+                            ? new Date(item.timestamp).toLocaleDateString('ko-KR', {
+                                month: 'short',
+                                day: 'numeric',
+                                hour: '2-digit',
+                                minute: '2-digit',
+                            })
+                            : '';
+
+                        return (
+                            <li key={item.id || idx}>
+                                <button
+                                    onClick={() => {
+                                        if (!isAnalyzing && item.user_idea) {
+                                            onSelectIdea(item.user_idea);
+                                        }
+                                    }}
+                                    disabled={isAnalyzing}
+                                    className={`w-full text-left p-3 rounded-lg border transition-all bg-white shadow-sm
+                                        ${isAnalyzing
+                                            ? 'opacity-50 cursor-not-allowed border-gray-100'
+                                            : 'border-slate-100 hover:border-blue-300 hover:bg-blue-50 cursor-pointer'
+                                        }`}
+                                >
+                                    <div className="flex items-center justify-between mb-1">
+                                        <span className="text-xs text-slate-400">{dateStr}</span>
+                                        {item.risk_level && (
+                                            <span className={`text-xs font-bold px-1.5 py-0.5 rounded ${getRiskBadgeStyle(item.risk_level)}`}>
+                                                {item.risk_level}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <p className="text-sm font-medium text-slate-700 line-clamp-2 leading-snug">
+                                        {preview}
+                                    </p>
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </aside>
+    );
+}
+
+// window.ENV 타입 전역 선언 (TypeScript 컴파일 오류 방지)
+declare global {
+    interface Window {
+        ENV?: {
+            API_BASE_URL?: string;
+            USER_ID?: string;
+        };
+    }
+}

--- a/frontend/src/hooks/useRagStream.ts
+++ b/frontend/src/hooks/useRagStream.ts
@@ -18,7 +18,11 @@ export function useRagStream() {
     // 진행중인 fetch 요청을 취소하기 위한 AbortController
     const abortControllerRef = useRef<AbortController | null>(null);
 
-    const startAnalysis = useCallback(async (idea: string) => {
+    const startAnalysis = useCallback(async (
+        userIdea: string,
+        ipcFilters: string[] | null = null,
+        useHybrid: boolean = true
+    ) => {
         setIsAnalyzing(true);
         setIsSkeletonVisible(true);
         setIsComplete(false);
@@ -47,13 +51,22 @@ export function useRagStream() {
             // 백엔드 FastAPI SSE 엔드포인트 호출 (POST)
             // 시니어 리뷰 반영: VITE_API_URL 환경변수 사용
             const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000';
-            const response = await fetch(`${apiUrl}/api/analyze`, {
+            // 백엔드 AnalyzeRequest 스키마 필드명에 맞춰 요청 Body 구성
+            const reqBody = {
+                user_idea: userIdea,
+                user_id: window.ENV?.USER_ID || 'test_user_webapp', // TODO: JWT 인증으로 교체 예정
+                use_hybrid: useHybrid,
+                ipc_filters: ipcFilters && ipcFilters.length > 0 ? ipcFilters : null,
+                stream: true,
+            };
+            // API 버전 prefix: /api/v1/analyze (app.js 기준으로 통일)
+            const response = await fetch(`${apiUrl}/api/v1/analyze`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                     'Accept': 'text/event-stream',
                 },
-                body: JSON.stringify({ idea }),
+                body: JSON.stringify(reqBody),
                 signal: abortController.signal
             });
 

--- a/frontend_review/25_senior_review_fix.md
+++ b/frontend_review/25_senior_review_fix.md
@@ -1,0 +1,68 @@
+# 🛠️ Frontend Critical 오류 수정 내역 (리뷰 반영)
+
+> **작업 기준**: `review/29_frontend_complete_declaration_review.md` Critical/Warning 항목 전체 반영
+> **작업일**: 2026-03-01
+
+---
+
+## 🎨 UI/UX 개발 내용 요약
+
+시니어 리뷰어(수석 아키텍트)가 발견한 **Critical 2건, Warning 2건**을 모두 수정했습니다.
+
+### 수정 항목별 상세
+
+#### [Critical 1] `History/HistorySidebar.tsx` 신규 구현
+- 파일이 전무했던 `frontend/src/components/History/` 폴더에 `HistorySidebar.tsx` 생성
+- 백엔드 `/api/v1/history?user_id=...` Query Parameter 방식으로 기록 조회
+- 로딩 스켈레톤, 에러 상태, 빈 히스토리 상태를 각각 별도 UI로 구현
+- 위험도(`risk_level`) 뱃지 색상 구분 (High=빨강, Medium=노랑, Low=초록)
+- `isAnalyzing=true` 중에는 항목 클릭 비활성화 처리
+
+#### [Critical 2] `App.tsx` 스트리밍 영역 하드코딩 제거
+- 기존: `"가상 LLM 스트리밍 텍스트 렌더링 시작됨... ▌"` 고정 문자열
+- 수정: `useRagStream` 훅의 `message` 상태를 직접 바인딩
+  ```tsx
+  // 수정 후
+  <p>{message || '특허 데이터베이스를 검색하고 있습니다...'}<span>▌</span></p>
+  ```
+
+#### [Warning 1] `useRagStream.ts` API 요청 Body 필드 통일
+- 기존: `{ idea }` → 백엔드 422 Validation Error 발생
+- 수정: 백엔드 `AnalyzeRequest` Pydantic 스키마에 맞게 전체 필드 포함
+  ```ts
+  const reqBody = {
+      user_idea: userIdea,
+      user_id: window.ENV?.USER_ID || 'test_user_webapp',
+      use_hybrid: useHybrid,
+      ipc_filters: ipcFilters,
+      stream: true,
+  };
+  ```
+
+#### [Warning 2] API 엔드포인트 prefix 통일
+- 기존: `/api/analyze` → 수정: `/api/v1/analyze` (app.js 기준으로 통일)
+
+#### [부가] `App.tsx` 2단 레이아웃 재구성
+- 기존: 단일 컬럼 중앙 정렬
+- 수정: 좌측 `HistorySidebar` + 우측 메인 콘텐츠의 반응형 2단 레이아웃
+- 헤더를 `<header>` 시맨틱 태그로 분리
+
+---
+
+## 📋 PM 및 Backend 전달용 피드백
+
+- **Epic: 프론트엔드 화면 개발**
+  - [x] `HistorySidebar.tsx` 신규 구현 및 `App.tsx`에 마운트 완료
+  - [x] 스트리밍 결과 영역 실제 상태 바인딩 완료
+  - [x] `useRagStream.ts` 요청 Body 백엔드 스키마 정합성 완료
+  - [x] API 엔드포인트 `/api/v1/analyze`로 통일 완료
+
+- **Epic: Backend에게 확인 요청할 사항**
+  - [ ] `GET /api/v1/history` 응답에 `risk_level` 필드 포함 여부 확인 요청
+    - `HistorySidebar`에서 위험도 뱃지를 렌더링하기 위해 `risk_level` 필드가 필요합니다.
+  - [ ] `POST /api/v1/analyze` 엔드포인트에서 `use_hybrid` 파라미터가 실제로 활성화되어 있는지 확인
+
+- **Epic: DevOps에게 확인 요청할 사항**
+  - [ ] Nginx/Docker 설정에서 `frontend/src/` (React Vite 빌드 산출물 `dist/`)를 서빙하는지 확인 필요
+    - `frontend/index.html` (바닐라 JS 버전)과 `frontend/src/main.tsx` (React 버전)이 여전히 공존 중
+    - 배포 시 어느 버전이 서빙될지 명확히 지정 필요

--- a/review/29_frontend_complete_declaration_review.md
+++ b/review/29_frontend_complete_declaration_review.md
@@ -1,0 +1,93 @@
+# 🔍 Frontend "Complete" 선언 교차 검토 리포트
+
+> **리뷰어**: 수석 아키텍트 (Senior Reviewer)
+> **검토 대상**: PM 분석 리포트 + 실제 `frontend/` 코드베이스 교차 검증
+> **검토 기준 파일**:
+> - `frontend/src/App.tsx`
+> - `frontend/src/hooks/useRagStream.ts`
+> - `frontend/src/components/**`
+> - `frontend/app.js`
+> **작성일**: 2026-03-01
+
+---
+
+### 🔍 총평 (Architecture Review)
+
+Frontend 에이전트의 "역할 종료 선언"은 **성급한 완료 선언**입니다. 핵심 UI 컴포넌트인 `History` 컴포넌트가 폴더만 존재하고 실제 파일이 없으며, `App.tsx`의 스트리밍 영역에 하드코딩된 플레이스홀더가 남아 있어 프로덕션 서빙이 불가능한 상태입니다. 또한 바닐라 JS 버전(`app.js`)과 React 버전(`src/`)이 공존하는 이중 아키텍처 문제가 해결되지 않아 배포 시 혼란을 야기할 수 있습니다.
+
+---
+
+### 🚨 코드 리뷰 피드백 (Frontend 에이전트 전달용)
+
+*(아래 내용을 복사해서 Frontend 에이전트에게 전달하세요)*
+
+---
+
+**[🔴 Critical: 치명적 결함 - 즉시 수정 필요]**
+
+- `frontend/src/components/History/` - **디렉토리가 존재하나 파일이 0개**
+  - PM 리포트 #10에서 "역할 종료 선언" 시 `History` 컴포넌트가 완성 항목으로 처리됐지만, 실제로 `History/` 폴더 안에 어떠한 `.tsx` 파일도 없습니다.
+  - `App.tsx`에도 히스토리 관련 렌더링 코드가 전혀 없습니다.
+  - 사용자가 이전 분석 기록을 조회하는 핵심 UX 기능이 **React 버전에서 완전히 누락**된 상태.
+  - **조치**: `HistorySidebar.tsx`(또는 `HistoryList.tsx`) 컴포넌트를 구현하고 `App.tsx` 렌더 트리에 마운트할 것.
+
+- `frontend/src/App.tsx:86` - **스트리밍 결과 영역이 하드코딩 플레이스홀더**
+  ```tsx
+  // ❌ 현재 코드 (프로덕션 불가)
+  <p className="text-gray-700 leading-relaxed font-mono">가상 LLM 스트리밍 텍스트 렌더링 시작됨... ▌</p>
+  ```
+  - `useRagStream` 훅이 실제 SSE 스트림을 수신하여 상태를 관리함에도, `App.tsx`는 해당 상태(`message`, `resultData`)를 이 영역에 바인딩하지 않고 고정 문자열을 노출 중.
+  - **조치**: 스켈레톤이 숨겨진 이후 노출되는 영역에 `message` 상태 또는 실시간 LLM 청크를 바인딩할 것.
+
+---
+
+**[🟡 Warning: 잠재적 위험 - 개선 권장]**
+
+- `frontend/app.js` + `frontend/index.html` (바닐라 JS 버전) vs `frontend/src/` (React 버전) - **이중 아키텍처 공존**
+  - 현재 두 서빙 진입점이 동시에 존재. Dockerfile 및 Nginx 설정에 따라 둘 중 하나가 잘못 서빙될 경우 전혀 다른 UI가 배포될 수 있음.
+  - **조치**: PM이 최종 서빙 버전을 결정하고, 레거시 버전은 `legacy/` 폴더로 이동하거나 삭제. DevOps 에이전트에게 `vite build` 산출물(`dist/`)을 Nginx가 서빙하도록 명시 요청할 것.
+
+- `frontend/src/hooks/useRagStream.ts:50` - **API 엔드포인트 경로 불일치 가능성**
+  ```ts
+  const response = await fetch(`${apiUrl}/api/analyze`, { ... });
+  ```
+  - `app.js`의 경로는 `/api/v1/analyze`이지만, `useRagStream.ts`는 `/api/analyze`로 `/v1` 버전 prefix가 없음.
+  - 백엔드 FastAPI의 실제 라우터 prefix와 반드시 맞춰야 함.
+  - **조치**: Backend 에이전트에게 실제 라우터 prefix(`/api/v1` vs `/api`)를 확인 후 통일할 것.
+
+- `frontend/src/hooks/useRagStream.ts:56` - **요청 Body 필드 불일치**
+  ```ts
+  body: JSON.stringify({ idea }),   // React 버전: "idea" 필드
+  ```
+  ```js
+  // app.js의 요청: "user_idea", "user_id", "use_hybrid", "ipc_filters" 필드
+  body: JSON.stringify({ user_idea, user_id, use_hybrid, ipc_filters })
+  ```
+  - 두 버전에서 백엔드로 보내는 필드명 자체가 다름. 백엔드 Pydantic 모델이 `user_idea`를 기대한다면 React 버전은 **즉시 422 Validation Error를 발생**시킴.
+  - **조치**: Backend의 `AnalyzeRequest` Pydantic 스키마를 확인 후 React 버전의 요청 Body를 일치시킬 것. `user_id`, `use_hybrid`, `ipc_filters` 필드도 포함 필요.
+
+---
+
+**[🟢 Info: 클린 코드 및 유지보수 제안]**
+
+- `frontend/FILE_STRUCTURE.md:12` - **문서가 구버전(Streamlit) 기준으로 작성됨**
+  - `app.py`를 "Streamlit 메인 앱"으로 기술하고 있으나, 현재 프로젝트는 React + FastAPI 구조로 전환된 상태.
+  - 문서의 신뢰도를 위해 `FILE_STRUCTURE.md`를 현행 아키텍처 기준으로 갱신 권장.
+
+- `frontend/src/App.tsx:6` - **`USER_ID`가 완전히 관리되지 않음**
+  - `app.js`에는 `USER_ID = 'test_user_webapp'` 하드코딩에 주석(`TODO: JWT로 교체`)이 있으나, React 버전(`App.tsx`)에는 `user_id` 전송 자체가 없음.
+  - 향후 인증 연동 시 양쪽을 모두 수정해야 하는 기술 부채 발생.
+  - **조치**: React 버전에서도 `user_id`를 환경변수 또는 Context로 관리하는 구조를 사전 설계할 것.
+
+---
+
+### 💡 Tech Lead의 머지(Merge) 권고
+
+- [ ] 이대로 Main 브랜치에 머지해도 좋습니다.
+- [x] **Critical 항목이 수정되기 전까지 머지를 보류하세요.**
+
+> **보류 사유**:
+> 1. `History` 컴포넌트 미구현으로 핵심 UX 기능 누락
+> 2. `App.tsx` 스트리밍 영역 하드코딩으로 실제 LLM 결과 미출력
+> 3. React vs 바닐라 JS 이중 아키텍처로 인한 배포 혼란 위험
+> 4. React 버전의 API 요청 필드(`idea`) ≠ 백엔드 기대 필드(`user_idea`) 불일치로 인한 즉각적 422 에러 예상


### PR DESCRIPTION
## UI/UX 개발 내용 요약

시니어 리뷰어(수석 아키텍트)가 발견한 **Critical 2건, Warning 2건**을 모두 수정했습니다.

### 수정 항목별 상세

#### [Critical 1] `History/HistorySidebar.tsx` 신규 구현

- 파일이 전무했던 `frontend/src/components/History/` 폴더에 `HistorySidebar.tsx` 생성
- 백엔드 `/api/v1/history?user_id=...` Query Parameter 방식으로 기록 조회
- 로딩 스켈레톤, 에러 상태, 빈 히스토리 상태를 각각 별도 UI로 구현
- 위험도(`risk_level`) 뱃지 색상 구분 (High=빨강, Medium=노랑, Low=초록)
- `isAnalyzing=true` 중에는 항목 클릭 비활성화 처리

#### [Critical 2] `App.tsx` 스트리밍 영역 하드코딩 제거

- 기존: `"가상 LLM 스트리밍 텍스트 렌더링 시작됨... ▌"` 고정 문자열
- 수정: `useRagStream` 훅의 `message` 상태를 직접 바인딩
  ```tsx
  // 수정 후
  <p>{message || '특허 데이터베이스를 검색하고 있습니다...'}<span>▌</span></p>
  ```

#### [Warning 1] `useRagStream.ts` API 요청 Body 필드 통일

- 기존: `{ idea }` → 백엔드 422 Validation Error 발생
- 수정: 백엔드 `AnalyzeRequest` Pydantic 스키마에 맞게 전체 필드 포함
  ```ts
  const reqBody = {
      user_idea: userIdea,
      user_id: window.ENV?.USER_ID || 'test_user_webapp',
      use_hybrid: useHybrid,
      ipc_filters: ipcFilters,
      stream: true,
  };
  ```

#### [Warning 2] API 엔드포인트 prefix 통일

- 기존: `/api/analyze` → 수정: `/api/v1/analyze` (app.js 기준으로 통일)

#### [부가] `App.tsx` 2단 레이아웃 재구성

- 기존: 단일 컬럼 중앙 정렬
- 수정: 좌측 `HistorySidebar` + 우측 메인 콘텐츠의 반응형 2단 레이아웃
- 헤더를 `<header>` 시맨틱 태그로 분리