### PR TITLE
feat: Issue #51 최종 완료 — SSE 파서 원복 및 임시 타입 제거

### DIFF
--- a/frontend/src/hooks/useRagStream.ts
+++ b/frontend/src/hooks/useRagStream.ts
@@ -94,9 +94,6 @@ export function useRagStream() {
             const reader = response.body.getReader();
             const decoder = new TextDecoder('utf-8');
             let buffer = '';
-            // Issue #51 임시 대응: Backend가 현재 NDJSON(\n 단위 JSON)을 내려줌
-            // TODO(Backend-SSE-전환 후): 아래 파서를 SSE(\n\n + event:/data: 방식)로 원복
-            let ndjsonPercent = 0; // percent 필드가 없을 경우 단계별 추정값
 
             while (true) {
                 const { value, done } = await reader.read();
@@ -105,35 +102,32 @@ export function useRagStream() {
                 // 청크 디코딩 후 버퍼에 누적
                 buffer += decoder.decode(value, { stream: true });
 
-                // [임시] NDJSON: \n 단위로 라인 분리 (SSE라면 \n\n 단위)
-                const lines = buffer.split('\n');
-                // 마지막 줄은 아직 불완전할 수 있으므로 버퍼에 남김
-                buffer = lines.pop() || '';
+                // SSE 표준: 이벤트 블록은 \n\n으로 구분
+                const blocks = buffer.split('\n\n');
+                // 마지막 블록은 아직 불완전할 수 있으므로 버퍼에 남김
+                buffer = blocks.pop() || '';
 
-                for (const line of lines) {
-                    if (!line.trim()) continue;
+                for (const block of blocks) {
+                    if (!block.trim()) continue;
 
-                    // SSE 표준 "data: ..." 형식도 같이 허용 (Backend 전환 시 자연스럽게 호환)
-                    let dataStr = line.trim();
-                    if (dataStr.startsWith('data:')) {
-                        dataStr = dataStr.replace(/^data:\s*/, '').trim();
-                    }
-                    if (!dataStr || dataStr.startsWith('event:') || dataStr.startsWith(':')) {
-                        continue; // event:, 주석 라인 무시
-                    }
+                    // 표준 SSE 이벤트 블록에서 event:와 data: 추출
+                    const eventMatch = block.match(/event:\s*([^\n]+)/);
+                    const dataMatch = block.match(/data:\s*([^\n]+)/);
+
+                    const eventType = eventMatch ? eventMatch[1].trim() : 'message';
+                    const dataStr = dataMatch ? dataMatch[1].trim() : '';
+
+                    if (!dataStr) continue;
 
                     try {
                         const parsed = JSON.parse(dataStr);
 
-                        // ── SSE 표준 방식 처리 (event type 기반) ──
-                        // Backend가 SSE로 전환하면 이 블록이 자동으로 동작
-                        if (parsed.percent !== undefined) {
-                            // percent 필드가 존재하면 SSE progress 방식
-                            if (parsed.percent >= 10) setIsSkeletonVisible(false);
-                            setPercent(parsed.percent);
+                        if (eventType === 'progress') {
+                            // 스켈레톤 숨김 (처음 progress 이벤트부터)
+                            setIsSkeletonVisible(false);
+                            setPercent(parsed.percent ?? 0);
                             setMessage(parsed.message || '분석 중...');
-                        } else if (parsed.result !== undefined) {
-                            // SSE complete 방식
+                        } else if (eventType === 'complete') {
                             setPercent(100);
                             setMessage('분석이 모두 완료되었습니다.');
                             setResultData(parsed.result);
@@ -141,37 +135,14 @@ export function useRagStream() {
                                 setIsAnalyzing(false);
                                 setIsComplete(true);
                             }, 1500);
-                        }
-                        // ── NDJSON 임시 방식 처리 (status 필드 기반) ──
-                        else if (parsed.status !== undefined) {
-                            if (parsed.status === 'processing') {
-                                // 첫 청크 도착 시 스켈레톤 숨김
-                                setIsSkeletonVisible(false);
-                                ndjsonPercent = Math.min(ndjsonPercent + 15, 40);
-                                setPercent(ndjsonPercent);
-                                setMessage(parsed.message || '분석을 시작합니다...');
-                            } else if (parsed.status === 'searching') {
-                                ndjsonPercent = Math.min(ndjsonPercent + 25, 80);
-                                setPercent(ndjsonPercent);
-                                setMessage(parsed.message || '특허 DB 검색 중...');
-                            } else if (parsed.status === 'complete') {
-                                setPercent(100);
-                                setMessage('분석이 모두 완료되었습니다.');
-                                if (parsed.result) setResultData(parsed.result);
-                                setTimeout(() => {
-                                    setIsAnalyzing(false);
-                                    setIsComplete(true);
-                                }, 1500);
-                            } else if (parsed.status === 'empty') {
-                                throw new Error('NOT_FOUND');
-                            } else if (parsed.status === 'error') {
-                                throw new Error('NETWORK_ERROR');
-                            }
+                        } else if (eventType === 'empty') {
+                            throw new Error('NOT_FOUND');
+                        } else if (eventType === 'error') {
+                            throw new Error('NETWORK_ERROR');
                         }
                     } catch (e: any) {
                         if (e.message === 'NOT_FOUND' || e.message === 'NETWORK_ERROR') throw e;
-                        // JSON 파싱 실패 — 원문 노출 방지를 위해 무시
-                        console.warn('[useRagStream] JSON 파싱 실패 (무시):', line.substring(0, 80));
+                        console.error('[useRagStream] SSE JSON 파싱 오류:', e, '원문:', dataStr.substring(0, 80));
                     }
                 }
             }

--- a/frontend/src/types/rag.ts
+++ b/frontend/src/types/rag.ts
@@ -41,15 +41,4 @@ export interface StreamCompleteEvent {
     result: RagAnalysisResult;
 }
 
-// ============================================================
-// Issue #51: 임시 NDJSON 호환 타입 (Backend SSE 전환 전까지 사용)
-// TODO: Backend가 SSE로 전환되면 아래 타입 제거
-// ============================================================
-
-/** Backend가 현재 내리는 단순 JSON 라인 형식 (임시) */
-export interface NdjsonStreamLine {
-    status: 'processing' | 'searching' | 'complete' | 'error' | 'empty';
-    message?: string;
-    percent?: number;
-    result?: RagAnalysisResult;
-}
+// ※ Backend SSE 전환 완료 (Issue #51) — NdjsonStreamLine 타입 제거됨

--- a/frontend_review/36_issue51_sse_parser_final.md
+++ b/frontend_review/36_issue51_sse_parser_final.md
@@ -1,0 +1,37 @@
+# ✅ Issue #51 최종 완료 — SSE 파서 원복 및 임시 타입 제거
+
+> **기준 리뷰**: `review/40_issue51_senior_review_final.md` (Approved)
+> **작업일**: 2026-03-02
+
+---
+
+## 🎨 UI/UX 개발 내용 요약
+
+Backend SSE 전환 승인(Merge Recommended)에 따라 Frontend 임시 NDJSON 파서를 완전히 제거하고 **표준 SSE 파서**로 원복했습니다. 코드가 더 단순하고 명확해졌습니다.
+
+### 변경 파일 1: `useRagStream.ts` (핵심)
+
+| 항목 | 이전 (임시) | 이후 (최종 SSE 표준) |
+|---|---|---|
+| 스트림 분리 | `\n` (NDJSON) | `\n\n` (SSE 표준 블록) |
+| 파싱 기준 | `status` 필드 | `event:` 필드 |
+| `event:progress` | 없음 | `setPercent`, `setMessage` |
+| `event:complete` | `status==='complete'` | `setResultData(parsed.result)` |
+| `event:empty/error` | `status` 분기 | 명시적 이벤트 타입 분기 |
+| ndjsonPercent 추정 | 있음 (임시) | **제거** — Backend가 percent 직접 제공 |
+
+### 변경 파일 2: `types/rag.ts`
+
+- `NdjsonStreamLine` 임시 인터페이스 **제거 완료**
+- `StreamEventType`, `StreamProgressEvent`, `StreamCompleteEvent` 유지 (SSE 계약 타입)
+
+---
+
+## 📋 PM 및 Backend 전달용 피드백
+
+- **Epic: 프론트엔드 화면 개발 (Issue #51 최종)**
+  - [x] `useRagStream.ts` — SSE 표준 파서로 원복 완료
+  - [x] `types/rag.ts` — 임시 NDJSON 타입 제거, SSE 계약 타입 유지
+  - [x] JSON 원문 노출 → `ProgressStepper` 로딩 UI 정상화 완료
+
+> **충돌(Conflict) 주의사항**: Backend 브랜치와 Frontend 브랜치를 머지할 때 `useRagStream.ts` 파일에서 충돌이 발생할 수 있습니다. 충돌 시 **Frontend SSE 표준 파서 버전을 기준**으로 유지하면 됩니다.


### PR DESCRIPTION
---

## 🎨 UI/UX 개발 내용 요약

Backend SSE 전환 승인(Merge Recommended)에 따라 Frontend 임시 NDJSON 파서를 완전히 제거하고 **표준 SSE 파서**로 원복했습니다. 코드가 더 단순하고 명확해졌습니다.

### 변경 파일 1: `useRagStream.ts` (핵심)

| 항목                  | 이전 (임시)             | 이후 (최종 SSE 표준)                          |
| --------------------- | ----------------------- | --------------------------------------------- |
| 스트림 분리           | `\n` (NDJSON)         | `\n\n` (SSE 표준 블록)                      |
| 파싱 기준             | `status` 필드         | `event:` 필드                               |
| `event:progress`    | 없음                    | `setPercent`, `setMessage`                |
| `event:complete`    | `status==='complete'` | `setResultData(parsed.result)`              |
| `event:empty/error` | `status` 분기         | 명시적 이벤트 타입 분기                       |
| ndjsonPercent 추정    | 있음 (임시)             | **제거** — Backend가 percent 직접 제공 |

### 변경 파일 2: `types/rag.ts`

- `NdjsonStreamLine` 임시 인터페이스 **제거 완료**
- `StreamEventType`, `StreamProgressEvent`, `StreamCompleteEvent` 유지 (SSE 계약 타입)

---

## 📋 PM 및 Backend 전달용 피드백

- **Epic: 프론트엔드 화면 개발 (Issue #51 최종)**
  - [X] `useRagStream.ts` — SSE 표준 파서로 원복 완료
  - [X] `types/rag.ts` — 임시 NDJSON 타입 제거, SSE 계약 타입 유지
  - [X] JSON 원문 노출 → `ProgressStepper` 로딩 UI 정상화 완료

> **충돌(Conflict) 주의사항**: Backend 브랜치와 Frontend 브랜치를 머지할 때 `useRagStream.ts` 파일에서 충돌이 발생할 수 있습니다. 충돌 시 **Frontend SSE 표준 파서 버전을 기준**으로 유지하면 됩니다.